### PR TITLE
Fetch five years of transaction history

### DIFF
--- a/ccSchwabManager/Views/HoldingsView/HoldingsView.swift
+++ b/ccSchwabManager/Views/HoldingsView/HoldingsView.swift
@@ -622,8 +622,8 @@ struct HoldingsView: View {
                 print("✅ Trade dates updated and cache populated")
             }
             
-            // Fetch remaining quarters in background for complete history
-            let remainingQuarters = min(SchwabClient.shared.maxQuarterDelta - 4, 8 )
+            // Fetch remaining quarters in background for complete history (up to maxQuarterDelta)
+            let remainingQuarters = max(SchwabClient.shared.maxQuarterDelta - 4, 0)
             if remainingQuarters > 0 {
                 print("🚀 Fetching remaining \(remainingQuarters) quarters in background")
                 


### PR DESCRIPTION
Increase fetched transaction history to 5 years by removing an artificial cap in `HoldingsView.swift`.

Previously, the background fetch for transaction history was capped at an additional 8 quarters, preventing the full 5-year history (20 quarters) from being retrieved. This change removes that specific cap, allowing the system to fetch up to `SchwabClient.shared.maxQuarterDelta`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7afd1851-2369-4534-a393-2ca4ad9fc75f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7afd1851-2369-4534-a393-2ca4ad9fc75f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

