### PR TITLE
Add when-over-5ATR-or-15% buy recommendation option

### DIFF
--- a/ccSchwabManager/DataTypes/OrderRecommendationService.swift
+++ b/ccSchwabManager/DataTypes/OrderRecommendationService.swift
@@ -407,6 +407,17 @@ class OrderRecommendationService: ObservableObject {
             }
         }
 
+        // Add 1-share buy that submits once position profit reaches min(5*ATR, 15%).
+        // This fills the gap for newly bought or only slightly profitable positions.
+        if let whenOverFiveATROrFifteenOrder = createWhenOverFiveATROrFifteenPercentBuyOrder(
+            symbol: symbol,
+            currentPrice: currentPrice,
+            atrValue: atrValue,
+            currentProfitPercent: currentProfitPercent
+        ) {
+            recommended.append(whenOverFiveATROrFifteenOrder)
+        }
+
         // 1-share buy: trailing stop = 2× the largest trailing stop among the other buy options already generated (e.g. max buy TS 9.49% → 18.98%)
         if let doubleMaxBuyTrailBuy = createOneShareBuyOrderDoublingMaxBuyTrail(
             symbol: symbol,
@@ -2508,6 +2519,55 @@ class OrderRecommendationService: ObservableObject {
             entryPrice: entryPrice,
             trailingStop: trailingStopPercent,
             targetGainPercent: targetGainPercent,
+            currentGainPercent: currentProfitPercent,
+            sharesToBuy: sharesToBuy,
+            orderCost: orderCost,
+            description: formattedDescription,
+            orderType: "BUY",
+            submitDate: "",
+            isImmediate: false
+        )
+    }
+
+    /// Creates a one-share buy recommendation that triggers when current holdings
+    /// become at least min(5*ATR%, 15%) profitable.
+    private func createWhenOverFiveATROrFifteenPercentBuyOrder(
+        symbol: String,
+        currentPrice: Double,
+        atrValue: Double,
+        currentProfitPercent: Double
+    ) -> BuyOrderRecord? {
+        let triggerProfitPercent = min(15.0, 5.0 * atrValue)
+        guard currentProfitPercent < triggerProfitPercent else { return nil }
+
+        let sharesToBuy: Double = 1.0
+        let trailingStopPercent = max(0.1, min(50.0, triggerProfitPercent - currentProfitPercent))
+        let stopPrice = currentPrice * (1.0 + trailingStopPercent / 100.0)
+        let finalTargetPrice = stopPrice * 1.02
+        let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
+        let orderCost = sharesToBuy * finalTargetPrice
+        guard orderCost < 2000.0 else { return nil }
+
+        let formattedDescription = String(
+            format: "BUY %.0f %@ (When over 5*ATR or 15%%) Trigger=%.2f%% CurrP/L=%.2f%% Target=%.2f TS=%.2f%% Cost=%.2f",
+            sharesToBuy,
+            symbol,
+            triggerProfitPercent,
+            currentProfitPercent,
+            finalTargetPrice,
+            trailingStopPercent,
+            orderCost
+        )
+
+        guard trailingStopPercent >= 0.1 && trailingStopPercent <= 50.0 else { return nil }
+        AppLogger.shared.debug("  One-share when-over-5*ATR-or-15% buy: trigger=\(triggerProfitPercent)%, currentP/L=\(currentProfitPercent)%, TS=\(trailingStopPercent)%")
+
+        return BuyOrderRecord(
+            shares: sharesToBuy,
+            targetBuyPrice: finalTargetPrice,
+            entryPrice: entryPrice,
+            trailingStop: trailingStopPercent,
+            targetGainPercent: triggerProfitPercent,
             currentGainPercent: currentProfitPercent,
             sharesToBuy: sharesToBuy,
             orderCost: orderCost,

--- a/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
+++ b/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
@@ -1054,6 +1054,168 @@ final class OrderRecommendationServiceTests: XCTestCase {
             XCTAssertLessThan(order.orderCost, 2000.0, "Order cost should be under $2000")
         }
     }
+
+    func testBuyOrder_IncludesWhenOverFiveATROrFifteenPercentOrder_WithPositiveProfitExample() async {
+        // Given: current profit 5%, ATR 2% -> trigger = min(15, 10) = 10%, TS = 10 - 5 = 5%
+        let avgCostPerShare = 100.0
+        let currentPrice = 105.0
+        let atrValue = 2.0
+        let taxLots = [
+            SalesCalcPositionsRecord(
+                openDate: "2023-01-01",
+                gainLossPct: 5.0,
+                gainLossDollar: 50.0,
+                quantity: 10.0,
+                price: currentPrice,
+                costPerShare: avgCostPerShare,
+                marketValue: 1050.0,
+                costBasis: 1000.0
+            )
+        ]
+        let (totalShares, totalCost, avgCost, currentProfitPercent) = calculatePositionValues(taxLots: taxLots, currentPrice: currentPrice)
+
+        // When
+        let result = service.calculateRecommendedBuyOrders(
+            symbol: "TEST",
+            atrValue: atrValue,
+            taxLotData: taxLots,
+            sharesAvailableForTrading: 10.0,
+            currentPrice: currentPrice,
+            totalShares: totalShares,
+            totalCost: totalCost,
+            avgCostPerShare: avgCost,
+            currentProfitPercent: currentProfitPercent
+        )
+
+        // Then
+        let order = result.first { $0.description.contains("When over 5*ATR or 15%") }
+        XCTAssertNotNil(order, "Should include when-over-5*ATR-or-15% recommendation when current profit is below trigger")
+        if let order {
+            XCTAssertEqual(order.shares, 1.0, accuracy: 0.001)
+            XCTAssertEqual(order.trailingStop, 5.0, accuracy: 0.01, "TS should be trigger-profit minus current profit (10 - 5)")
+        }
+    }
+
+    func testBuyOrder_IncludesWhenOverFiveATROrFifteenPercentOrder_WithNegativeProfitAndFifteenCap() async {
+        // Given: current profit -2%, ATR 6% -> trigger = min(15, 30) = 15%, TS = 15 - (-2) = 17%
+        let avgCostPerShare = 100.0
+        let currentPrice = 98.0
+        let atrValue = 6.0
+        let taxLots = [
+            SalesCalcPositionsRecord(
+                openDate: "2023-01-01",
+                gainLossPct: -2.0,
+                gainLossDollar: -20.0,
+                quantity: 10.0,
+                price: currentPrice,
+                costPerShare: avgCostPerShare,
+                marketValue: 980.0,
+                costBasis: 1000.0
+            )
+        ]
+        let (totalShares, totalCost, avgCost, currentProfitPercent) = calculatePositionValues(taxLots: taxLots, currentPrice: currentPrice)
+
+        // When
+        let result = service.calculateRecommendedBuyOrders(
+            symbol: "TEST",
+            atrValue: atrValue,
+            taxLotData: taxLots,
+            sharesAvailableForTrading: 10.0,
+            currentPrice: currentPrice,
+            totalShares: totalShares,
+            totalCost: totalCost,
+            avgCostPerShare: avgCost,
+            currentProfitPercent: currentProfitPercent
+        )
+
+        // Then
+        let order = result.first { $0.description.contains("When over 5*ATR or 15%") }
+        XCTAssertNotNil(order, "Should include when-over recommendation for negative-profit position")
+        if let order {
+            XCTAssertEqual(order.shares, 1.0, accuracy: 0.001)
+            XCTAssertEqual(order.trailingStop, 17.0, accuracy: 0.01, "TS should be 15 - (-2) when 15% cap applies")
+        }
+    }
+
+    func testBuyOrder_IncludesWhenOverFiveATROrFifteenPercentOrder_WithNegativeProfitAndATRTrigger() async {
+        // Given: current profit -2%, ATR 2% -> trigger = min(15, 10) = 10%, TS = 10 - (-2) = 12%
+        let avgCostPerShare = 100.0
+        let currentPrice = 98.0
+        let atrValue = 2.0
+        let taxLots = [
+            SalesCalcPositionsRecord(
+                openDate: "2023-01-01",
+                gainLossPct: -2.0,
+                gainLossDollar: -20.0,
+                quantity: 10.0,
+                price: currentPrice,
+                costPerShare: avgCostPerShare,
+                marketValue: 980.0,
+                costBasis: 1000.0
+            )
+        ]
+        let (totalShares, totalCost, avgCost, currentProfitPercent) = calculatePositionValues(taxLots: taxLots, currentPrice: currentPrice)
+
+        // When
+        let result = service.calculateRecommendedBuyOrders(
+            symbol: "TEST",
+            atrValue: atrValue,
+            taxLotData: taxLots,
+            sharesAvailableForTrading: 10.0,
+            currentPrice: currentPrice,
+            totalShares: totalShares,
+            totalCost: totalCost,
+            avgCostPerShare: avgCost,
+            currentProfitPercent: currentProfitPercent
+        )
+
+        // Then
+        let order = result.first { $0.description.contains("When over 5*ATR or 15%") }
+        XCTAssertNotNil(order, "Should include when-over recommendation for negative-profit position below ATR trigger")
+        if let order {
+            XCTAssertEqual(order.shares, 1.0, accuracy: 0.001)
+            XCTAssertEqual(order.trailingStop, 12.0, accuracy: 0.01, "TS should be 10 - (-2) when ATR trigger applies")
+        }
+    }
+
+    func testBuyOrder_WhenOverFiveATROrFifteenPercentOrder_NotIncludedAtOrAboveTrigger() async {
+        // Given: current profit 12%, ATR 2% -> trigger = 10%, so order should not be emitted
+        let avgCostPerShare = 100.0
+        let currentPrice = 112.0
+        let atrValue = 2.0
+        let taxLots = [
+            SalesCalcPositionsRecord(
+                openDate: "2023-01-01",
+                gainLossPct: 12.0,
+                gainLossDollar: 120.0,
+                quantity: 10.0,
+                price: currentPrice,
+                costPerShare: avgCostPerShare,
+                marketValue: 1120.0,
+                costBasis: 1000.0
+            )
+        ]
+        let (totalShares, totalCost, avgCost, currentProfitPercent) = calculatePositionValues(taxLots: taxLots, currentPrice: currentPrice)
+
+        // When
+        let result = service.calculateRecommendedBuyOrders(
+            symbol: "TEST",
+            atrValue: atrValue,
+            taxLotData: taxLots,
+            sharesAvailableForTrading: 10.0,
+            currentPrice: currentPrice,
+            totalShares: totalShares,
+            totalCost: totalCost,
+            avgCostPerShare: avgCost,
+            currentProfitPercent: currentProfitPercent
+        )
+
+        // Then
+        XCTAssertNil(
+            result.first { $0.description.contains("When over 5*ATR or 15%") },
+            "Should not include when-over recommendation when current profit is already at or above trigger"
+        )
+    }
     
     // MARK: - Performance Tests
     func testPerformance_CalculateRecommendedSellOrders()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new buy recommendation option for existing positions: "When over 5*ATR or 15%"
- emit this option only when current position profit is below `min(15, 5*ATR)`
- calculate trailing stop as `min(15, 5*ATR) - currentProfitPercent`, matching requested behavior for recently purchased, unprofitable, or slightly profitable securities
- include targeted tests for:
  - current profit 5%, ATR 2% -> TS 5%
  - current profit -2%, ATR 6% -> TS 17%
  - current profit -2%, ATR 2% -> TS 12%
  - no recommendation when current profit is already above trigger

## Validation
- attempted focused unit tests and platform builds using repository scripts and direct commands
- environment is Linux without Swift/Xcode toolchain (`swift` and `xcodebuild` unavailable), so macOS/iOS build, test, archive, and verify commands cannot run in this environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93668b7c-dca6-483e-9f85-f02954846d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93668b7c-dca6-483e-9f85-f02954846d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

