### PR TITLE
Improve current-order delta comparison and best-trade matching

### DIFF
--- a/ccSchwabManager/DataTypes/OrderRecommendationService.swift
+++ b/ccSchwabManager/DataTypes/OrderRecommendationService.swift
@@ -319,12 +319,31 @@ class OrderRecommendationService: ObservableObject {
             }
         }
         
-        // Add $2500 buy order option (similar to $500 option)
-        if let twentyFiveHundredDollarOrder = createTwentyFiveHundredDollarBuyOrder(
+        // Add explicit fixed-dollar buy order options.
+        if let thousandDollarOrder = createFixedDollarBuyOrder(
             symbol: symbol,
             currentPrice: currentPrice,
             atrValue: atrValue,
-            targetGainPercent: targetGainPercent
+            targetGainPercent: targetGainPercent,
+            budgetDollars: 1000.0
+        ) {
+            recommended.append(thousandDollarOrder)
+        }
+        if let fifteenHundredDollarOrder = createFixedDollarBuyOrder(
+            symbol: symbol,
+            currentPrice: currentPrice,
+            atrValue: atrValue,
+            targetGainPercent: targetGainPercent,
+            budgetDollars: 1500.0
+        ) {
+            recommended.append(fifteenHundredDollarOrder)
+        }
+        if let twentyFiveHundredDollarOrder = createFixedDollarBuyOrder(
+            symbol: symbol,
+            currentPrice: currentPrice,
+            atrValue: atrValue,
+            targetGainPercent: targetGainPercent,
+            budgetDollars: 2500.0
         ) {
             recommended.append(twentyFiveHundredDollarOrder)
         }
@@ -2249,25 +2268,28 @@ class OrderRecommendationService: ObservableObject {
         return additionalBuyOrder
     }
     
-    /// Creates a $2500 buy order option (similar to $500 option)
+    /// Creates a fixed-dollar buy order option (similar to the existing $500 option).
     /// - Parameters:
     ///   - symbol: The trading symbol
     ///   - currentPrice: Current market price
     ///   - atrValue: Average True Range value
     ///   - targetGainPercent: Target gain percentage
+    ///   - budgetDollars: Dollar budget used to size the order.
     /// - Returns: Buy order record or nil if not applicable
-    private func createTwentyFiveHundredDollarBuyOrder(
+    private func createFixedDollarBuyOrder(
         symbol: String,
         currentPrice: Double,
         atrValue: Double,
-        targetGainPercent: Double
+        targetGainPercent: Double,
+        budgetDollars: Double
     ) -> BuyOrderRecord? {
-        
-        // Calculate number of shares that can be bought for $2500, rounded up
-        let sharesFor2500 = ceil(2500.0 / currentPrice)
+        guard budgetDollars > 0 else { return nil }
+
+        // Calculate number of shares that can be bought for the budget, rounded up.
+        let sharesForBudget = ceil(budgetDollars / currentPrice)
         
         // Ensure we have at least 1 share
-        guard sharesFor2500 >= 1.0 else { return nil }
+        guard sharesForBudget >= 1.0 else { return nil }
         
         // Calculate target price (maintains the same target gain percentage)
         let targetBuyPrice = currentPrice * (1.0 + targetGainPercent / 100.0)
@@ -2283,38 +2305,39 @@ class OrderRecommendationService: ObservableObject {
         // Calculate entry price (1 ATR below target)
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         
-        AppLogger.shared.debug("  $2500 buy order: ATR=\(atrValue)%, trailingStopPercent=\(trailingStopPercent)%")
+        AppLogger.shared.debug("  $\(budgetDollars) buy order: ATR=\(atrValue)%, trailingStopPercent=\(trailingStopPercent)%")
         
         // Calculate actual order cost
-        let orderCost = sharesFor2500 * finalTargetPrice
+        let orderCost = sharesForBudget * finalTargetPrice
         
         // Create description
         let formattedDescription = String(
-            format: "BUY %.0f %@ ($2500) Target=%.2f TS=%.1f%% Gain=%.1f%% Cost=%.2f",
-            sharesFor2500,
+            format: "BUY %.0f %@ ($%.0f) Target=%.2f TS=%.1f%% Gain=%.1f%% Cost=%.2f",
+            sharesForBudget,
             symbol,
+            budgetDollars,
             finalTargetPrice,
             trailingStopPercent,
             targetGainPercent,
             orderCost
         )
         
-        AppLogger.shared.debug("  Creating $2500 buy order: trailingStop=\(trailingStopPercent)%, shares=\(sharesFor2500), target=\(finalTargetPrice)")
+        AppLogger.shared.debug("  Creating $\(budgetDollars) buy order: trailingStop=\(trailingStopPercent)%, shares=\(sharesForBudget), target=\(finalTargetPrice)")
         
         // Final validation of trailing stop value
         guard trailingStopPercent >= 0.1 && trailingStopPercent <= 50.0 else {
-            AppLogger.shared.error("⚠️ Invalid trailing stop value in $2500 buy order: \(trailingStopPercent)%")
+            AppLogger.shared.error("⚠️ Invalid trailing stop value in $\(budgetDollars) buy order: \(trailingStopPercent)%")
             return nil
         }
         
-        let twentyFiveHundredDollarOrder = BuyOrderRecord(
-            shares: sharesFor2500,
+        let fixedDollarOrder = BuyOrderRecord(
+            shares: sharesForBudget,
             targetBuyPrice: finalTargetPrice,
             entryPrice: entryPrice,
             trailingStop: trailingStopPercent,
             targetGainPercent: targetGainPercent,
             currentGainPercent: 0.0, // No existing position gain for this additional order
-            sharesToBuy: sharesFor2500,
+            sharesToBuy: sharesForBudget,
             orderCost: orderCost,
             description: formattedDescription,
             orderType: "BUY",
@@ -2322,7 +2345,7 @@ class OrderRecommendationService: ObservableObject {
             isImmediate: false
         )
         
-        return twentyFiveHundredDollarOrder
+        return fixedDollarOrder
     }
     
     /// Creates a profit-based buy order when position is more than 20% profitable

--- a/ccSchwabManager/DataTypes/OrderRecommendationService.swift
+++ b/ccSchwabManager/DataTypes/OrderRecommendationService.swift
@@ -266,7 +266,7 @@ class OrderRecommendationService: ObservableObject {
             let orderCost = sharesToBuy * finalTargetPrice
             
             // Skip orders that cost more than $2000
-            guard orderCost < 1750.0 else { continue }
+            guard orderCost < 2500.0 else { continue }
             
             // Create the buy order
             let formattedDescription = String(
@@ -319,14 +319,14 @@ class OrderRecommendationService: ObservableObject {
             }
         }
         
-        // Add $1750 buy order option (similar to $500 option)
-        if let seventeenFiftyDollarOrder = createSeventeenFiftyDollarBuyOrder(
+        // Add $2500 buy order option (similar to $500 option)
+        if let twentyFiveHundredDollarOrder = createTwentyFiveHundredDollarBuyOrder(
             symbol: symbol,
             currentPrice: currentPrice,
             atrValue: atrValue,
             targetGainPercent: targetGainPercent
         ) {
-            recommended.append(seventeenFiftyDollarOrder)
+            recommended.append(twentyFiveHundredDollarOrder)
         }
         
         // Add profit-based buy order when position is more than 20% profitable
@@ -367,7 +367,7 @@ class OrderRecommendationService: ObservableObject {
                 let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
 
                 let orderCost = sharesToBuy * finalTargetPrice
-                if orderCost < 1750.0 {
+                if orderCost < 2500.0 {
                     let formattedDescription = String(
                         format: "BUY %.0f %@ (5%% DAY) Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",
                         sharesToBuy,
@@ -2249,25 +2249,25 @@ class OrderRecommendationService: ObservableObject {
         return additionalBuyOrder
     }
     
-    /// Creates a $1750 buy order option (similar to $500 option)
+    /// Creates a $2500 buy order option (similar to $500 option)
     /// - Parameters:
     ///   - symbol: The trading symbol
     ///   - currentPrice: Current market price
     ///   - atrValue: Average True Range value
     ///   - targetGainPercent: Target gain percentage
     /// - Returns: Buy order record or nil if not applicable
-    private func createSeventeenFiftyDollarBuyOrder(
+    private func createTwentyFiveHundredDollarBuyOrder(
         symbol: String,
         currentPrice: Double,
         atrValue: Double,
         targetGainPercent: Double
     ) -> BuyOrderRecord? {
         
-        // Calculate number of shares that can be bought for $1750, rounded up
-        let sharesFor1750 = ceil(1750.0 / currentPrice)
+        // Calculate number of shares that can be bought for $2500, rounded up
+        let sharesFor2500 = ceil(2500.0 / currentPrice)
         
         // Ensure we have at least 1 share
-        guard sharesFor1750 >= 1.0 else { return nil }
+        guard sharesFor2500 >= 1.0 else { return nil }
         
         // Calculate target price (maintains the same target gain percentage)
         let targetBuyPrice = currentPrice * (1.0 + targetGainPercent / 100.0)
@@ -2283,15 +2283,15 @@ class OrderRecommendationService: ObservableObject {
         // Calculate entry price (1 ATR below target)
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         
-        AppLogger.shared.debug("  $1750 buy order: ATR=\(atrValue)%, trailingStopPercent=\(trailingStopPercent)%")
+        AppLogger.shared.debug("  $2500 buy order: ATR=\(atrValue)%, trailingStopPercent=\(trailingStopPercent)%")
         
         // Calculate actual order cost
-        let orderCost = sharesFor1750 * finalTargetPrice
+        let orderCost = sharesFor2500 * finalTargetPrice
         
         // Create description
         let formattedDescription = String(
-            format: "BUY %.0f %@ ($1750) Target=%.2f TS=%.1f%% Gain=%.1f%% Cost=%.2f",
-            sharesFor1750,
+            format: "BUY %.0f %@ ($2500) Target=%.2f TS=%.1f%% Gain=%.1f%% Cost=%.2f",
+            sharesFor2500,
             symbol,
             finalTargetPrice,
             trailingStopPercent,
@@ -2299,22 +2299,22 @@ class OrderRecommendationService: ObservableObject {
             orderCost
         )
         
-        AppLogger.shared.debug("  Creating $1750 buy order: trailingStop=\(trailingStopPercent)%, shares=\(sharesFor1750), target=\(finalTargetPrice)")
+        AppLogger.shared.debug("  Creating $2500 buy order: trailingStop=\(trailingStopPercent)%, shares=\(sharesFor2500), target=\(finalTargetPrice)")
         
         // Final validation of trailing stop value
         guard trailingStopPercent >= 0.1 && trailingStopPercent <= 50.0 else {
-            AppLogger.shared.error("⚠️ Invalid trailing stop value in $1750 buy order: \(trailingStopPercent)%")
+            AppLogger.shared.error("⚠️ Invalid trailing stop value in $2500 buy order: \(trailingStopPercent)%")
             return nil
         }
         
-        let seventeenFiftyDollarOrder = BuyOrderRecord(
-            shares: sharesFor1750,
+        let twentyFiveHundredDollarOrder = BuyOrderRecord(
+            shares: sharesFor2500,
             targetBuyPrice: finalTargetPrice,
             entryPrice: entryPrice,
             trailingStop: trailingStopPercent,
             targetGainPercent: targetGainPercent,
             currentGainPercent: 0.0, // No existing position gain for this additional order
-            sharesToBuy: sharesFor1750,
+            sharesToBuy: sharesFor2500,
             orderCost: orderCost,
             description: formattedDescription,
             orderType: "BUY",
@@ -2322,7 +2322,7 @@ class OrderRecommendationService: ObservableObject {
             isImmediate: false
         )
         
-        return seventeenFiftyDollarOrder
+        return twentyFiveHundredDollarOrder
     }
     
     /// Creates a profit-based buy order when position is more than 20% profitable
@@ -2387,7 +2387,7 @@ class OrderRecommendationService: ObservableObject {
         let orderCost = sharesToBuy * finalTargetPrice
         
         // Skip orders that cost more than $2000
-        guard orderCost < 1750.0 else { return nil }
+        guard orderCost < 2500.0 else { return nil }
         
         // Create description
         let formattedDescription = String(
@@ -2450,7 +2450,7 @@ class OrderRecommendationService: ObservableObject {
         
         // Order cost threshold consistent with other small buys ($2000 cap)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 1750.0 else { return nil }
+        guard orderCost < 2500.0 else { return nil }
         
         let formattedDescription = String(
             format: "BUY %.0f %@ (1 sh, 5%%+ATR) Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",
@@ -2506,7 +2506,7 @@ class OrderRecommendationService: ObservableObject {
 
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 1750.0 else { return nil }
+        guard orderCost < 2500.0 else { return nil }
 
         let formattedDescription = String(
             format: "BUY %.0f %@ (1 sh, 2x max buy TS %.2f%%) Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",
@@ -2556,7 +2556,7 @@ class OrderRecommendationService: ObservableObject {
         let finalTargetPrice = stopPrice * 1.02
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 1750.0 else { return nil }
+        guard orderCost < 2500.0 else { return nil }
 
         let formattedDescription = String(
             format: "BUY %.0f %@ (When over 5*ATR or 15%%) Trigger=%.2f%% CurrP/L=%.2f%% Target=%.2f TS=%.2f%% Cost=%.2f",
@@ -2629,7 +2629,7 @@ class OrderRecommendationService: ObservableObject {
         
         // Order cost threshold consistent with other small buys ($2000 cap)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 1750.0 else { return nil }
+        guard orderCost < 2500.0 else { return nil }
         
         let formattedDescription = String(
             format: "BUY %.0f %@ (When Profitable) P/L=%.1f%% Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",

--- a/ccSchwabManager/DataTypes/OrderRecommendationService.swift
+++ b/ccSchwabManager/DataTypes/OrderRecommendationService.swift
@@ -266,7 +266,7 @@ class OrderRecommendationService: ObservableObject {
             let orderCost = sharesToBuy * finalTargetPrice
             
             // Skip orders that cost more than $2000
-            guard orderCost < 2000.0 else { continue }
+            guard orderCost < 1750.0 else { continue }
             
             // Create the buy order
             let formattedDescription = String(
@@ -319,14 +319,14 @@ class OrderRecommendationService: ObservableObject {
             }
         }
         
-        // Add $1000 buy order option (similar to $500 option)
-        if let thousandDollarOrder = createThousandDollarBuyOrder(
+        // Add $1750 buy order option (similar to $500 option)
+        if let seventeenFiftyDollarOrder = createSeventeenFiftyDollarBuyOrder(
             symbol: symbol,
             currentPrice: currentPrice,
             atrValue: atrValue,
             targetGainPercent: targetGainPercent
         ) {
-            recommended.append(thousandDollarOrder)
+            recommended.append(seventeenFiftyDollarOrder)
         }
         
         // Add profit-based buy order when position is more than 20% profitable
@@ -367,7 +367,7 @@ class OrderRecommendationService: ObservableObject {
                 let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
 
                 let orderCost = sharesToBuy * finalTargetPrice
-                if orderCost < 2000.0 {
+                if orderCost < 1750.0 {
                     let formattedDescription = String(
                         format: "BUY %.0f %@ (5%% DAY) Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",
                         sharesToBuy,
@@ -2249,25 +2249,25 @@ class OrderRecommendationService: ObservableObject {
         return additionalBuyOrder
     }
     
-    /// Creates a $1000 buy order option (similar to $500 option)
+    /// Creates a $1750 buy order option (similar to $500 option)
     /// - Parameters:
     ///   - symbol: The trading symbol
     ///   - currentPrice: Current market price
     ///   - atrValue: Average True Range value
     ///   - targetGainPercent: Target gain percentage
     /// - Returns: Buy order record or nil if not applicable
-    private func createThousandDollarBuyOrder(
+    private func createSeventeenFiftyDollarBuyOrder(
         symbol: String,
         currentPrice: Double,
         atrValue: Double,
         targetGainPercent: Double
     ) -> BuyOrderRecord? {
         
-        // Calculate number of shares that can be bought for $1000, rounded up
-        let sharesFor1000 = ceil(1000.0 / currentPrice)
+        // Calculate number of shares that can be bought for $1750, rounded up
+        let sharesFor1750 = ceil(1750.0 / currentPrice)
         
         // Ensure we have at least 1 share
-        guard sharesFor1000 >= 1.0 else { return nil }
+        guard sharesFor1750 >= 1.0 else { return nil }
         
         // Calculate target price (maintains the same target gain percentage)
         let targetBuyPrice = currentPrice * (1.0 + targetGainPercent / 100.0)
@@ -2283,15 +2283,15 @@ class OrderRecommendationService: ObservableObject {
         // Calculate entry price (1 ATR below target)
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         
-        AppLogger.shared.debug("  $1000 buy order: ATR=\(atrValue)%, trailingStopPercent=\(trailingStopPercent)%")
+        AppLogger.shared.debug("  $1750 buy order: ATR=\(atrValue)%, trailingStopPercent=\(trailingStopPercent)%")
         
         // Calculate actual order cost
-        let orderCost = sharesFor1000 * finalTargetPrice
+        let orderCost = sharesFor1750 * finalTargetPrice
         
         // Create description
         let formattedDescription = String(
-            format: "BUY %.0f %@ ($1000) Target=%.2f TS=%.1f%% Gain=%.1f%% Cost=%.2f",
-            sharesFor1000,
+            format: "BUY %.0f %@ ($1750) Target=%.2f TS=%.1f%% Gain=%.1f%% Cost=%.2f",
+            sharesFor1750,
             symbol,
             finalTargetPrice,
             trailingStopPercent,
@@ -2299,22 +2299,22 @@ class OrderRecommendationService: ObservableObject {
             orderCost
         )
         
-        AppLogger.shared.debug("  Creating $1000 buy order: trailingStop=\(trailingStopPercent)%, shares=\(sharesFor1000), target=\(finalTargetPrice)")
+        AppLogger.shared.debug("  Creating $1750 buy order: trailingStop=\(trailingStopPercent)%, shares=\(sharesFor1750), target=\(finalTargetPrice)")
         
         // Final validation of trailing stop value
         guard trailingStopPercent >= 0.1 && trailingStopPercent <= 50.0 else {
-            AppLogger.shared.error("⚠️ Invalid trailing stop value in $1000 buy order: \(trailingStopPercent)%")
+            AppLogger.shared.error("⚠️ Invalid trailing stop value in $1750 buy order: \(trailingStopPercent)%")
             return nil
         }
         
-        let thousandDollarOrder = BuyOrderRecord(
-            shares: sharesFor1000,
+        let seventeenFiftyDollarOrder = BuyOrderRecord(
+            shares: sharesFor1750,
             targetBuyPrice: finalTargetPrice,
             entryPrice: entryPrice,
             trailingStop: trailingStopPercent,
             targetGainPercent: targetGainPercent,
             currentGainPercent: 0.0, // No existing position gain for this additional order
-            sharesToBuy: sharesFor1000,
+            sharesToBuy: sharesFor1750,
             orderCost: orderCost,
             description: formattedDescription,
             orderType: "BUY",
@@ -2322,7 +2322,7 @@ class OrderRecommendationService: ObservableObject {
             isImmediate: false
         )
         
-        return thousandDollarOrder
+        return seventeenFiftyDollarOrder
     }
     
     /// Creates a profit-based buy order when position is more than 20% profitable
@@ -2387,7 +2387,7 @@ class OrderRecommendationService: ObservableObject {
         let orderCost = sharesToBuy * finalTargetPrice
         
         // Skip orders that cost more than $2000
-        guard orderCost < 2000.0 else { return nil }
+        guard orderCost < 1750.0 else { return nil }
         
         // Create description
         let formattedDescription = String(
@@ -2450,7 +2450,7 @@ class OrderRecommendationService: ObservableObject {
         
         // Order cost threshold consistent with other small buys ($2000 cap)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 2000.0 else { return nil }
+        guard orderCost < 1750.0 else { return nil }
         
         let formattedDescription = String(
             format: "BUY %.0f %@ (1 sh, 5%%+ATR) Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",
@@ -2506,7 +2506,7 @@ class OrderRecommendationService: ObservableObject {
 
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 2000.0 else { return nil }
+        guard orderCost < 1750.0 else { return nil }
 
         let formattedDescription = String(
             format: "BUY %.0f %@ (1 sh, 2x max buy TS %.2f%%) Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",
@@ -2556,7 +2556,7 @@ class OrderRecommendationService: ObservableObject {
         let finalTargetPrice = stopPrice * 1.02
         let entryPrice = finalTargetPrice * (1.0 - atrValue / 100.0)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 2000.0 else { return nil }
+        guard orderCost < 1750.0 else { return nil }
 
         let formattedDescription = String(
             format: "BUY %.0f %@ (When over 5*ATR or 15%%) Trigger=%.2f%% CurrP/L=%.2f%% Target=%.2f TS=%.2f%% Cost=%.2f",
@@ -2629,7 +2629,7 @@ class OrderRecommendationService: ObservableObject {
         
         // Order cost threshold consistent with other small buys ($2000 cap)
         let orderCost = sharesToBuy * finalTargetPrice
-        guard orderCost < 2000.0 else { return nil }
+        guard orderCost < 1750.0 else { return nil }
         
         let formattedDescription = String(
             format: "BUY %.0f %@ (When Profitable) P/L=%.1f%% Target=%.2f TS=%.2f%% Gain=%.1f%% Cost=%.2f",

--- a/ccSchwabManager/Views/HoldingsView/PositionDetailView/PositionDetailContent/CurrentOrdersTab/CurrentOrdersSection/CurrentOrderDisplayInfo.swift
+++ b/ccSchwabManager/Views/HoldingsView/PositionDetailView/PositionDetailContent/CurrentOrdersTab/CurrentOrdersSection/CurrentOrderDisplayInfo.swift
@@ -240,6 +240,9 @@ struct RecommendedOrderDisplayInfo: Identifiable {
     let targetPrice: Double
     let trailPercent: Double
     let estimatedStopPrice: Double?
+    let breakEvenPrice: Double?
+    let gainPercent: Double?
+    let targetGainPercent: Double?
     /// Free-form label like `Top 100`, `Min ATR`, or `Buy`.
     let sourceLabel: String
     let description: String
@@ -266,6 +269,9 @@ extension RecommendedOrderDisplayInfo {
             targetPrice: sell.target,
             trailPercent: sell.trailingStop,
             estimatedStopPrice: estimated,
+            breakEvenPrice: sell.breakEven,
+            gainPercent: sell.gain,
+            targetGainPercent: sell.gain,
             sourceLabel: extractSourceLabel(from: sell.description, fallback: "Sell"),
             description: sell.description
         )
@@ -291,6 +297,9 @@ extension RecommendedOrderDisplayInfo {
             targetPrice: buy.targetBuyPrice,
             trailPercent: buy.trailingStop,
             estimatedStopPrice: estimated,
+            breakEvenPrice: nil,
+            gainPercent: nil,
+            targetGainPercent: buy.targetGainPercent,
             sourceLabel: extractSourceLabel(from: buy.description, fallback: "Buy"),
             description: buy.description
         )
@@ -312,12 +321,75 @@ extension RecommendedOrderDisplayInfo {
     }
 }
 
+extension RecommendedOrderDisplayInfo {
+    var atrMultipleHint: Double {
+        if let value = Self.extractATRMultiple(from: sourceLabel) {
+            return value
+        }
+        if let value = Self.extractATRMultiple(from: description) {
+            return value
+        }
+        if sourceLabel.localizedCaseInsensitiveContains("Min ATR")
+            || description.localizedCaseInsensitiveContains("Min ATR") {
+            return 1.0
+        }
+        return 0.0
+    }
+
+    var isWhenOverFiveATROrFifteenBuy: Bool {
+        description.localizedCaseInsensitiveContains("When over 5*ATR or 15%")
+    }
+
+    var isProfitableSell: Bool {
+        guard kind == .sell else { return true }
+        if let gainPercent {
+            return gainPercent > 0
+        }
+        if let breakEvenPrice {
+            return targetPrice > breakEvenPrice
+        }
+        return true
+    }
+
+    var keepsHighProfitBuyTrigger: Bool {
+        guard kind == .buy else { return false }
+        if isWhenOverFiveATROrFifteenBuy { return true }
+        return (targetGainPercent ?? 0) >= 15.0
+    }
+
+    private static func extractATRMultiple(from text: String) -> Double? {
+        let pattern = #"([0-9]+(?:\.[0-9]+)?)\s*\*ATR"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              let valueRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+        return Double(text[valueRange])
+    }
+}
+
 // MARK: - Comparison
 
 /// Pairing of a current order with the closest matching recommendation
 /// (if any). All deltas are computed as `recommendation - current` so the
 /// UI can render `+`/`-` labels without further math.
 struct OrderComparisonInfo {
+    enum DeltaMetric {
+        case quantity
+        case target
+        case trail
+        case estimatedStop
+    }
+
+    enum DeltaSentiment {
+        case better
+        case worse
+        case neutral
+    }
+
     let current: CurrentOrderDisplayInfo
     let suggestion: RecommendedOrderDisplayInfo?
     let qtyDelta: Double?
@@ -354,40 +426,120 @@ struct OrderComparisonInfo {
             self.estStopDelta = nil
         }
     }
+
+    func delta(for metric: DeltaMetric) -> Double? {
+        switch metric {
+        case .quantity: return qtyDelta
+        case .target: return targetDelta
+        case .trail: return trailDelta
+        case .estimatedStop: return estStopDelta
+        }
+    }
+
+    func sentiment(for metric: DeltaMetric) -> DeltaSentiment? {
+        guard let value = delta(for: metric) else { return nil }
+        if abs(value) < 0.0001 { return .neutral }
+
+        switch metric {
+        case .quantity:
+            return value < 0 ? .better : .worse
+        case .target:
+            return value > 0 ? .better : .worse
+        case .trail:
+            return value > 0 ? .better : .worse
+        case .estimatedStop:
+            switch current.side {
+            case .sell:
+                return value < 0 ? .better : .worse
+            case .buy:
+                return value > 0 ? .better : .worse
+            case .unknown:
+                return .neutral
+            }
+        }
+    }
 }
 
 enum OrderComparisonMatcher {
-    /// Pick the recommendation closest to `current` based on side, then a
-    /// normalized blend of target-price difference and quantity difference.
+    /// Pick the best replacement recommendation for `current` based on side-specific
+    /// objectives (not simply nearest values).
     static func bestMatch(
         for current: CurrentOrderDisplayInfo,
         sells: [RecommendedOrderDisplayInfo],
         buys: [RecommendedOrderDisplayInfo]
     ) -> RecommendedOrderDisplayInfo? {
-        let candidates: [RecommendedOrderDisplayInfo]
         switch current.side {
-        case .sell: candidates = sells
-        case .buy: candidates = buys
+        case .sell:
+            return bestSellReplacement(from: sells)
+        case .buy:
+            return bestBuyReplacement(from: buys)
         case .unknown: return nil
         }
-        guard !candidates.isEmpty else { return nil }
+    }
 
-        let curTarget = current.limitPrice ?? current.stopPrice ?? current.estimatedStopPrice ?? 0
-        let curQty = current.quantity
+    private static func bestSellReplacement(from sells: [RecommendedOrderDisplayInfo]) -> RecommendedOrderDisplayInfo? {
+        let profitable = sells.filter { $0.isProfitableSell }
+        guard !profitable.isEmpty else { return nil }
 
-        var best: (RecommendedOrderDisplayInfo, Double)?
-        for candidate in candidates {
-            let priceWeight = max(curTarget, candidate.targetPrice, 1.0)
-            let qtyWeight = max(curQty, candidate.quantity, 1.0)
-            let priceDiff = curTarget > 0 ? abs(candidate.targetPrice - curTarget) / priceWeight : 0
-            let qtyDiff = abs(candidate.quantity - curQty) / qtyWeight
-            let score = priceDiff + qtyDiff
-            if let cur = best {
-                if score < cur.1 { best = (candidate, score) }
-            } else {
-                best = (candidate, score)
-            }
+        let fiveATRPlus = profitable.filter { $0.atrMultipleHint >= 5.0 }
+        if let preferred = prioritizeSellCandidates(fiveATRPlus, fewerSharesPreferred: true) {
+            return preferred
         }
-        return best?.0
+
+        let threeATRPlus = profitable.filter { $0.atrMultipleHint >= 3.0 }
+        if let preferred = prioritizeSellCandidates(threeATRPlus, fewerSharesPreferred: true) {
+            return preferred
+        }
+
+        return prioritizeSellCandidates(profitable, fewerSharesPreferred: false)
+    }
+
+    private static func prioritizeSellCandidates(
+        _ candidates: [RecommendedOrderDisplayInfo],
+        fewerSharesPreferred: Bool
+    ) -> RecommendedOrderDisplayInfo? {
+        guard !candidates.isEmpty else { return nil }
+        return candidates.sorted { lhs, rhs in
+            if lhs.quantity != rhs.quantity {
+                return fewerSharesPreferred ? (lhs.quantity < rhs.quantity) : (lhs.quantity > rhs.quantity)
+            }
+            if lhs.atrMultipleHint != rhs.atrMultipleHint {
+                return lhs.atrMultipleHint > rhs.atrMultipleHint
+            }
+            if lhs.trailPercent != rhs.trailPercent {
+                return lhs.trailPercent > rhs.trailPercent
+            }
+            if lhs.targetPrice != rhs.targetPrice {
+                return lhs.targetPrice > rhs.targetPrice
+            }
+            return lhs.description < rhs.description
+        }.first
+    }
+
+    private static func bestBuyReplacement(from buys: [RecommendedOrderDisplayInfo]) -> RecommendedOrderDisplayInfo? {
+        guard !buys.isEmpty else { return nil }
+        let highProfitCandidates = buys.filter { $0.keepsHighProfitBuyTrigger }
+        let candidatePool = highProfitCandidates.isEmpty ? buys : highProfitCandidates
+
+        return candidatePool.sorted { lhs, rhs in
+            if lhs.isWhenOverFiveATROrFifteenBuy != rhs.isWhenOverFiveATROrFifteenBuy {
+                return lhs.isWhenOverFiveATROrFifteenBuy
+            }
+            if lhs.trailPercent != rhs.trailPercent {
+                return lhs.trailPercent > rhs.trailPercent
+            }
+            if lhs.quantity != rhs.quantity {
+                return lhs.quantity < rhs.quantity
+            }
+            let lhsGain = lhs.targetGainPercent ?? lhs.gainPercent ?? 0
+            let rhsGain = rhs.targetGainPercent ?? rhs.gainPercent ?? 0
+            if lhsGain != rhsGain {
+                return lhsGain > rhsGain
+            }
+            if lhs.targetPrice != rhs.targetPrice {
+                return lhs.targetPrice > rhs.targetPrice
+        }
+            return lhs.description < rhs.description
+        }.first
     }
 }

--- a/ccSchwabManager/Views/HoldingsView/PositionDetailView/PositionDetailContent/CurrentOrdersTab/CurrentOrdersSection/CurrentOrderDisplayInfo.swift
+++ b/ccSchwabManager/Views/HoldingsView/PositionDetailView/PositionDetailContent/CurrentOrdersTab/CurrentOrdersSection/CurrentOrderDisplayInfo.swift
@@ -340,6 +340,29 @@ extension RecommendedOrderDisplayInfo {
         description.localizedCaseInsensitiveContains("When over 5*ATR or 15%")
     }
 
+    var isWhenProfitableBuy: Bool {
+        description.localizedCaseInsensitiveContains("When Profitable")
+    }
+
+    var isProfitBasedP10Buy: Bool {
+        description.localizedCaseInsensitiveContains("(P/10")
+    }
+
+    var isTrimBuy: Bool {
+        description.localizedCaseInsensitiveContains("trim")
+    }
+
+    var isFallbackTriggerBuy: Bool {
+        isTrimBuy || isWhenOverFiveATROrFifteenBuy || isWhenProfitableBuy
+    }
+
+    var fallbackTriggerPriority: Int {
+        if isTrimBuy { return 0 }
+        if isWhenOverFiveATROrFifteenBuy { return 1 }
+        if isWhenProfitableBuy { return 2 }
+        return 3
+    }
+
     var isProfitableSell: Bool {
         guard kind == .sell else { return true }
         if let gainPercent {
@@ -353,7 +376,7 @@ extension RecommendedOrderDisplayInfo {
 
     var keepsHighProfitBuyTrigger: Bool {
         guard kind == .buy else { return false }
-        if isWhenOverFiveATROrFifteenBuy { return true }
+        if isProfitBasedP10Buy || isFallbackTriggerBuy { return true }
         return (targetGainPercent ?? 0) >= 15.0
     }
 
@@ -518,27 +541,58 @@ enum OrderComparisonMatcher {
 
     private static func bestBuyReplacement(from buys: [RecommendedOrderDisplayInfo]) -> RecommendedOrderDisplayInfo? {
         guard !buys.isEmpty else { return nil }
-        let highProfitCandidates = buys.filter { $0.keepsHighProfitBuyTrigger }
-        let candidatePool = highProfitCandidates.isEmpty ? buys : highProfitCandidates
 
-        return candidatePool.sorted { lhs, rhs in
-            if lhs.isWhenOverFiveATROrFifteenBuy != rhs.isWhenOverFiveATROrFifteenBuy {
-                return lhs.isWhenOverFiveATROrFifteenBuy
-            }
-            if lhs.trailPercent != rhs.trailPercent {
-                return lhs.trailPercent > rhs.trailPercent
+        let profitableCandidates = buys.filter { $0.keepsHighProfitBuyTrigger }
+        let candidatePool = profitableCandidates.isEmpty ? buys : profitableCandidates
+
+        let p10Candidates = candidatePool.filter { $0.isProfitBasedP10Buy }
+        if let p10Best = prioritizeBuyBySizeThenPrice(p10Candidates) {
+            return p10Best
+        }
+
+        let fallbackCandidates = candidatePool.filter { $0.isFallbackTriggerBuy }
+        if let fallback = fallbackCandidates.sorted(by: { lhs, rhs in
+            if lhs.fallbackTriggerPriority != rhs.fallbackTriggerPriority {
+                return lhs.fallbackTriggerPriority < rhs.fallbackTriggerPriority
             }
             if lhs.quantity != rhs.quantity {
-                return lhs.quantity < rhs.quantity
+                return lhs.quantity > rhs.quantity
+            }
+            if lhs.targetPrice != rhs.targetPrice {
+                return lhs.targetPrice < rhs.targetPrice
             }
             let lhsGain = lhs.targetGainPercent ?? lhs.gainPercent ?? 0
             let rhsGain = rhs.targetGainPercent ?? rhs.gainPercent ?? 0
             if lhsGain != rhsGain {
                 return lhsGain > rhsGain
             }
-            if lhs.targetPrice != rhs.targetPrice {
-                return lhs.targetPrice > rhs.targetPrice
+            return lhs.description < rhs.description
+        }).first {
+            return fallback
         }
+
+        return prioritizeBuyBySizeThenPrice(candidatePool)
+    }
+
+    private static func prioritizeBuyBySizeThenPrice(
+        _ candidates: [RecommendedOrderDisplayInfo]
+    ) -> RecommendedOrderDisplayInfo? {
+        guard !candidates.isEmpty else { return nil }
+        return candidates.sorted { lhs, rhs in
+            if lhs.quantity != rhs.quantity {
+                return lhs.quantity > rhs.quantity
+            }
+            if lhs.targetPrice != rhs.targetPrice {
+                return lhs.targetPrice < rhs.targetPrice
+            }
+            let lhsGain = lhs.targetGainPercent ?? lhs.gainPercent ?? 0
+            let rhsGain = rhs.targetGainPercent ?? rhs.gainPercent ?? 0
+            if lhsGain != rhsGain {
+                return lhsGain > rhsGain
+            }
+            if lhs.trailPercent != rhs.trailPercent {
+                return lhs.trailPercent > rhs.trailPercent
+            }
             return lhs.description < rhs.description
         }.first
     }

--- a/ccSchwabManager/Views/HoldingsView/PositionDetailView/PositionDetailContent/CurrentOrdersTab/CurrentOrdersSection/OrderDetailRow.swift
+++ b/ccSchwabManager/Views/HoldingsView/PositionDetailView/PositionDetailContent/CurrentOrdersTab/CurrentOrdersSection/OrderDetailRow.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct OrderDetailRow: View {
+    private struct DeltaLabel: Identifiable {
+        let id = UUID()
+        let text: String
+        let sentiment: OrderComparisonInfo.DeltaSentiment
+    }
+
     let order: Order
     let groupOrderId: Int64?
     /// Latest quote for the symbol; used to estimate the live trailing stop price.
@@ -248,13 +254,13 @@ struct OrderDetailRow: View {
 
                 if let comparison = comparison, hasAnyDelta(comparison) {
                     HStack(spacing: 6) {
-                        ForEach(deltaLabels(comparison), id: \.self) { label in
-                            Text(label)
+                        ForEach(deltaLabels(comparison)) { label in
+                            Text(label.text)
                                 .font(.caption2)
-                                .foregroundColor(.secondary)
+                                .foregroundColor(deltaTextColor(label.sentiment))
                                 .padding(.horizontal, 5)
                                 .padding(.vertical, 1)
-                                .background(Color.secondary.opacity(0.08))
+                                .background(deltaBackgroundColor(label.sentiment))
                                 .cornerRadius(3)
                         }
                         Spacer(minLength: 0)
@@ -289,21 +295,57 @@ struct OrderDetailRow: View {
             || comparison.estStopDelta != nil
     }
 
-    private func deltaLabels(_ comparison: OrderComparisonInfo) -> [String] {
-        var labels: [String] = []
+    private func deltaLabels(_ comparison: OrderComparisonInfo) -> [DeltaLabel] {
+        var labels: [DeltaLabel] = []
         if let qty = comparison.qtyDelta {
-            labels.append("ΔQty \(signed(qty, format: "%.0f"))")
+            labels.append(
+                DeltaLabel(
+                    text: "ΔQty \(signed(qty, format: "%.0f"))",
+                    sentiment: comparison.sentiment(for: .quantity) ?? .neutral
+                )
+            )
         }
         if let target = comparison.targetDelta {
-            labels.append("ΔTarget \(signed(target, format: "%.2f"))")
+            labels.append(
+                DeltaLabel(
+                    text: "ΔTarget \(signed(target, format: "%.2f"))",
+                    sentiment: comparison.sentiment(for: .target) ?? .neutral
+                )
+            )
         }
         if let trail = comparison.trailDelta {
-            labels.append("ΔTrail \(signed(trail, format: "%.2f"))%")
+            labels.append(
+                DeltaLabel(
+                    text: "ΔTrail \(signed(trail, format: "%.2f"))%",
+                    sentiment: comparison.sentiment(for: .trail) ?? .neutral
+                )
+            )
         }
         if let stop = comparison.estStopDelta {
-            labels.append("ΔStop \(signed(stop, format: "%.2f"))")
+            labels.append(
+                DeltaLabel(
+                    text: "ΔStop \(signed(stop, format: "%.2f"))",
+                    sentiment: comparison.sentiment(for: .estimatedStop) ?? .neutral
+                )
+            )
         }
         return labels
+    }
+
+    private func deltaTextColor(_ sentiment: OrderComparisonInfo.DeltaSentiment) -> Color {
+        switch sentiment {
+        case .better: return .green
+        case .worse: return .red
+        case .neutral: return .secondary
+        }
+    }
+
+    private func deltaBackgroundColor(_ sentiment: OrderComparisonInfo.DeltaSentiment) -> Color {
+        switch sentiment {
+        case .better: return Color.green.opacity(0.14)
+        case .worse: return Color.red.opacity(0.14)
+        case .neutral: return Color.secondary.opacity(0.08)
+        }
     }
 
     private func signed(_ value: Double, format: String) -> String {

--- a/ccSchwabManagerTests/BuyOrderCalculationTests.swift
+++ b/ccSchwabManagerTests/BuyOrderCalculationTests.swift
@@ -341,8 +341,8 @@ class BuyOrderCalculationTests: XCTestCase {
     }
     
     func testOrderCostLimit() {
-        // Test that buy orders are limited to those costing less than $2000
-        let currentPrice = 50.0  // Lower price to keep order cost under $2000
+        // Test that buy orders are limited to those costing less than $1750
+        let currentPrice = 50.0  // Lower price to keep order cost under $1750
         let avgCostPerShare = 40.0
         let totalShares = 100.0
         let sharesToBuy = 25.0 // 25% of current shares
@@ -362,14 +362,14 @@ class BuyOrderCalculationTests: XCTestCase {
         // Calculate order cost
         let orderCost = sharesToBuy * constrainedTargetPrice
         
-        // Verify the order cost is less than $2000
-        XCTAssertLessThan(orderCost, 2000.0, "Order cost should be less than $2000")
+        // Verify the order cost is less than $1750
+        XCTAssertLessThan(orderCost, 1750.0, "Order cost should be less than $1750")
         
         // Test with a high-priced stock that would exceed the limit
         let highPriceStock = 200.0
         let highPriceShares = 15.0
         let highPriceOrderCost = highPriceShares * highPriceStock // $3000
         
-        XCTAssertGreaterThan(highPriceOrderCost, 2000.0, "High price order should exceed $2000 limit")
+        XCTAssertGreaterThan(highPriceOrderCost, 1750.0, "High price order should exceed $1750 limit")
     }
 } 

--- a/ccSchwabManagerTests/BuyOrderCalculationTests.swift
+++ b/ccSchwabManagerTests/BuyOrderCalculationTests.swift
@@ -341,8 +341,8 @@ class BuyOrderCalculationTests: XCTestCase {
     }
     
     func testOrderCostLimit() {
-        // Test that buy orders are limited to those costing less than $1750
-        let currentPrice = 50.0  // Lower price to keep order cost under $1750
+        // Test that buy orders are limited to those costing less than $2500
+        let currentPrice = 50.0  // Lower price to keep order cost under $2500
         let avgCostPerShare = 40.0
         let totalShares = 100.0
         let sharesToBuy = 25.0 // 25% of current shares
@@ -362,14 +362,14 @@ class BuyOrderCalculationTests: XCTestCase {
         // Calculate order cost
         let orderCost = sharesToBuy * constrainedTargetPrice
         
-        // Verify the order cost is less than $1750
-        XCTAssertLessThan(orderCost, 1750.0, "Order cost should be less than $1750")
+        // Verify the order cost is less than $2500
+        XCTAssertLessThan(orderCost, 2500.0, "Order cost should be less than $2500")
         
         // Test with a high-priced stock that would exceed the limit
         let highPriceStock = 200.0
         let highPriceShares = 15.0
         let highPriceOrderCost = highPriceShares * highPriceStock // $3000
         
-        XCTAssertGreaterThan(highPriceOrderCost, 1750.0, "High price order should exceed $1750 limit")
+        XCTAssertGreaterThan(highPriceOrderCost, 2500.0, "High price order should exceed $2500 limit")
     }
 } 

--- a/ccSchwabManagerTests/OrderComparisonMatcherTests.swift
+++ b/ccSchwabManagerTests/OrderComparisonMatcherTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+@testable import ccSchwabManager
+
+@MainActor
+final class OrderComparisonMatcherTests: XCTestCase {
+    private func makeCurrentOrder(
+        side: CurrentOrderSide,
+        quantity: Double = 100,
+        limitPrice: Double? = 100,
+        trailPercent: Double? = 2.0
+    ) -> CurrentOrderDisplayInfo {
+        let symbol = side == .sell ? "SELLSYM" : "BUYSYM"
+        let instruction: OrderInstructionType = side == .sell ? .SELL_TO_CLOSE : .BUY_TO_OPEN
+        let leg = OrderLegCollection(
+            instrument: AccountsInstrument(symbol: symbol),
+            instruction: instruction,
+            positionEffect: side == .sell ? .CLOSING : .OPENING,
+            quantity: quantity
+        )
+        let order = Order(
+            duration: .GOOD_TILL_CANCEL,
+            orderType: .TRAILING_STOP_LIMIT,
+            quantity: quantity,
+            stopPriceLinkBasis: side == .sell ? .ASK : .BID,
+            stopPriceLinkType: .PERCENT,
+            stopPriceOffset: trailPercent,
+            price: limitPrice,
+            orderLegCollection: [leg],
+            orderStrategyType: .SINGLE,
+            orderId: 999_001,
+            status: .working
+        )
+        let quote = Quote(askPrice: 101, bidPrice: 99, lastPrice: 100, mark: 100)
+        guard let info = CurrentOrderDisplayInfo(
+            order: order,
+            groupOrderId: order.orderId,
+            quote: quote,
+            lastPriceFallback: 100
+        ) else {
+            fatalError("Failed to construct CurrentOrderDisplayInfo test fixture")
+        }
+        return info
+    }
+
+    private func sellRecommendation(
+        shares: Double,
+        trailingStop: Double,
+        target: Double = 105,
+        breakEven: Double = 100,
+        gain: Double = 5,
+        description: String
+    ) -> RecommendedOrderDisplayInfo {
+        let record = SalesCalcResultsRecord(
+            shares: shares,
+            rollingGainLoss: (target - breakEven) * shares,
+            breakEven: breakEven,
+            gain: gain,
+            sharesToSell: shares,
+            trailingStop: trailingStop,
+            entry: target + 1,
+            target: target,
+            cancel: target - 1,
+            description: description,
+            openDate: "test"
+        )
+        return RecommendedOrderDisplayInfo.from(
+            sell: record,
+            quote: Quote(askPrice: 101, bidPrice: 99, lastPrice: 100, mark: 100),
+            lastPriceFallback: 100
+        )
+    }
+
+    private func buyRecommendation(
+        shares: Double,
+        trailingStop: Double,
+        targetBuyPrice: Double = 110,
+        targetGainPercent: Double = 15,
+        description: String
+    ) -> RecommendedOrderDisplayInfo {
+        let record = BuyOrderRecord(
+            shares: shares,
+            targetBuyPrice: targetBuyPrice,
+            entryPrice: targetBuyPrice - 2,
+            trailingStop: trailingStop,
+            targetGainPercent: targetGainPercent,
+            currentGainPercent: 5,
+            sharesToBuy: shares,
+            orderCost: shares * targetBuyPrice,
+            description: description,
+            orderType: "BUY",
+            submitDate: "",
+            isImmediate: false
+        )
+        return RecommendedOrderDisplayInfo.from(
+            buy: record,
+            quote: Quote(askPrice: 101, bidPrice: 99, lastPrice: 100, mark: 100),
+            lastPriceFallback: 100
+        )
+    }
+
+    func testBestSellReplacement_PrefersFiveATRWithFewestShares() {
+        let current = makeCurrentOrder(side: .sell)
+        let candidates = [
+            sellRecommendation(shares: 50, trailingStop: 3, description: "(3*ATR) SELL -50 TEST"),
+            sellRecommendation(shares: 40, trailingStop: 5, description: "(5*ATR) SELL -40 TEST"),
+            sellRecommendation(shares: 30, trailingStop: 5, description: "(5*ATR) SELL -30 TEST")
+        ]
+
+        let best = OrderComparisonMatcher.bestMatch(for: current, sells: candidates, buys: [])
+
+        XCTAssertNotNil(best)
+        XCTAssertEqual(best?.sourceLabel, "5*ATR")
+        XCTAssertEqual(best?.quantity, 30, accuracy: 0.001)
+    }
+
+    func testBestSellReplacement_FallsBackToMaxSharesWhenNoThreeATR() {
+        let current = makeCurrentOrder(side: .sell)
+        let candidates = [
+            sellRecommendation(shares: 30, trailingStop: 1.5, description: "(Top 100) SELL -30 TEST"),
+            sellRecommendation(shares: 45, trailingStop: 2.0, description: "(Min BE) SELL -45 TEST")
+        ]
+
+        let best = OrderComparisonMatcher.bestMatch(for: current, sells: candidates, buys: [])
+
+        XCTAssertNotNil(best)
+        XCTAssertEqual(best?.quantity, 45, accuracy: 0.001)
+    }
+
+    func testBestSellReplacement_RejectsUnprofitableCandidates() {
+        let current = makeCurrentOrder(side: .sell)
+        let candidates = [
+            sellRecommendation(
+                shares: 10,
+                trailingStop: 5,
+                target: 98,
+                breakEven: 100,
+                gain: -2,
+                description: "(5*ATR) SELL -10 TEST"
+            )
+        ]
+
+        let best = OrderComparisonMatcher.bestMatch(for: current, sells: candidates, buys: [])
+
+        XCTAssertNil(best)
+    }
+
+    func testBestBuyReplacement_PrefersWhenOverRecommendation() {
+        let current = makeCurrentOrder(side: .buy, quantity: 1, limitPrice: 105, trailPercent: 4)
+        let candidates = [
+            buyRecommendation(
+                shares: 1,
+                trailingStop: 12,
+                targetBuyPrice: 114,
+                targetGainPercent: 15,
+                description: "BUY 1 XYZ (When over 5*ATR or 15%) Trigger=12.0% CurrP/L=4.0% Target=114 TS=8%"
+            ),
+            buyRecommendation(
+                shares: 1,
+                trailingStop: 20,
+                targetBuyPrice: 116,
+                targetGainPercent: 15,
+                description: "BUY 1 XYZ (1 sh, 2x max buy TS 10.00%) Target=116 TS=20%"
+            )
+        ]
+
+        let best = OrderComparisonMatcher.bestMatch(for: current, sells: [], buys: candidates)
+
+        XCTAssertNotNil(best)
+        XCTAssertTrue(best?.isWhenOverFiveATROrFifteenBuy == true)
+    }
+
+    func testBestBuyReplacement_UsesHighTrailThenLowestShares() {
+        let current = makeCurrentOrder(side: .buy, quantity: 5, limitPrice: 103, trailPercent: 3)
+        let candidates = [
+            buyRecommendation(
+                shares: 2,
+                trailingStop: 9,
+                targetBuyPrice: 111,
+                targetGainPercent: 15,
+                description: "BUY 2 XYZ (high gain A) Target=111 TS=9%"
+            ),
+            buyRecommendation(
+                shares: 1,
+                trailingStop: 9,
+                targetBuyPrice: 110,
+                targetGainPercent: 15,
+                description: "BUY 1 XYZ (high gain B) Target=110 TS=9%"
+            ),
+            buyRecommendation(
+                shares: 1,
+                trailingStop: 7,
+                targetBuyPrice: 109,
+                targetGainPercent: 15,
+                description: "BUY 1 XYZ (lower trail) Target=109 TS=7%"
+            )
+        ]
+
+        let best = OrderComparisonMatcher.bestMatch(for: current, sells: [], buys: candidates)
+
+        XCTAssertNotNil(best)
+        XCTAssertEqual(best?.trailPercent, 9, accuracy: 0.001)
+        XCTAssertEqual(best?.quantity, 1, accuracy: 0.001)
+    }
+
+    func testDeltaSentiment_ReflectsDirectionalImprovementBySide() {
+        let currentSell = makeCurrentOrder(side: .sell, quantity: 80, limitPrice: 100, trailPercent: 3)
+        let improvedSellSuggestion = sellRecommendation(
+            shares: 40,
+            trailingStop: 5,
+            target: 110,
+            description: "(5*ATR) SELL -40 TEST"
+        )
+        let sellComparison = OrderComparisonInfo(current: currentSell, suggestion: improvedSellSuggestion)
+        XCTAssertEqual(sellComparison.sentiment(for: .quantity), .better)
+        XCTAssertEqual(sellComparison.sentiment(for: .target), .better)
+        XCTAssertEqual(sellComparison.sentiment(for: .trail), .better)
+
+        let currentBuy = makeCurrentOrder(side: .buy, quantity: 1, limitPrice: 105, trailPercent: 6)
+        let worseBuySuggestion = buyRecommendation(
+            shares: 5,
+            trailingStop: 4,
+            targetBuyPrice: 103,
+            targetGainPercent: 10,
+            description: "BUY 5 XYZ (weaker buy) Target=103 TS=4%"
+        )
+        let buyComparison = OrderComparisonInfo(current: currentBuy, suggestion: worseBuySuggestion)
+        XCTAssertEqual(buyComparison.sentiment(for: .quantity), .worse)
+        XCTAssertEqual(buyComparison.sentiment(for: .target), .worse)
+        XCTAssertEqual(buyComparison.sentiment(for: .trail), .worse)
+    }
+}

--- a/ccSchwabManagerTests/OrderComparisonMatcherTests.swift
+++ b/ccSchwabManagerTests/OrderComparisonMatcherTests.swift
@@ -144,9 +144,16 @@ final class OrderComparisonMatcherTests: XCTestCase {
         XCTAssertNil(best)
     }
 
-    func testBestBuyReplacement_PrefersWhenOverRecommendation() {
+    func testBestBuyReplacement_PrefersProfitBasedP10Recommendation() {
         let current = makeCurrentOrder(side: .buy, quantity: 1, limitPrice: 105, trailPercent: 4)
         let candidates = [
+            buyRecommendation(
+                shares: 3,
+                trailingStop: 13.5,
+                targetBuyPrice: 111,
+                targetGainPercent: 33.8,
+                description: "BUY 3 XYZ (P/10, P/L=27.6%) Target=111 TS=13.5% Gain=33.8% Cost=333"
+            ),
             buyRecommendation(
                 shares: 1,
                 trailingStop: 12,
@@ -166,40 +173,41 @@ final class OrderComparisonMatcherTests: XCTestCase {
         let best = OrderComparisonMatcher.bestMatch(for: current, sells: [], buys: candidates)
 
         XCTAssertNotNil(best)
-        XCTAssertTrue(best?.isWhenOverFiveATROrFifteenBuy == true)
+        XCTAssertTrue(best?.isProfitBasedP10Buy == true)
     }
 
-    func testBestBuyReplacement_UsesHighTrailThenLowestShares() {
+    func testBestBuyReplacement_FallbackUsesMostSharesThenLowestTarget() {
         let current = makeCurrentOrder(side: .buy, quantity: 5, limitPrice: 103, trailPercent: 3)
         let candidates = [
             buyRecommendation(
-                shares: 2,
+                shares: 5,
                 trailingStop: 9,
-                targetBuyPrice: 111,
+                targetBuyPrice: 111.5,
                 targetGainPercent: 15,
-                description: "BUY 2 XYZ (high gain A) Target=111 TS=9%"
+                description: "BUY 5 XYZ (When over 5*ATR or 15%) Trigger=12.0% CurrP/L=4.0% Target=111.5 TS=9%"
             ),
             buyRecommendation(
                 shares: 1,
-                trailingStop: 9,
-                targetBuyPrice: 110,
+                trailingStop: 20,
+                targetBuyPrice: 109.5,
                 targetGainPercent: 15,
-                description: "BUY 1 XYZ (high gain B) Target=110 TS=9%"
+                description: "BUY 1 XYZ (When Profitable) P/L=-2.0% Target=109.5 TS=20%"
             ),
             buyRecommendation(
-                shares: 1,
-                trailingStop: 7,
-                targetBuyPrice: 109,
+                shares: 5,
+                trailingStop: 8,
+                targetBuyPrice: 110.0,
                 targetGainPercent: 15,
-                description: "BUY 1 XYZ (lower trail) Target=109 TS=7%"
+                description: "BUY 5 XYZ (When over 5*ATR or 15%) Trigger=11.0% CurrP/L=6.0% Target=110.0 TS=8%"
             )
         ]
 
         let best = OrderComparisonMatcher.bestMatch(for: current, sells: [], buys: candidates)
 
         XCTAssertNotNil(best)
-        XCTAssertEqual(best?.trailPercent, 9, accuracy: 0.001)
-        XCTAssertEqual(best?.quantity, 1, accuracy: 0.001)
+        XCTAssertTrue(best?.isWhenOverFiveATROrFifteenBuy == true)
+        XCTAssertEqual(best?.quantity, 5, accuracy: 0.001)
+        XCTAssertEqual(best?.targetPrice, 110.0, accuracy: 0.001)
     }
 
     func testDeltaSentiment_ReflectsDirectionalImprovementBySide() {

--- a/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
+++ b/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
@@ -577,6 +577,40 @@ final class OrderRecommendationServiceTests: XCTestCase {
         
         XCTAssertNil(additionalOrder, "Should not include additional buy order for securities above $350")
     }
+
+    func testCalculateRecommendedBuyOrders_IncludesExplicitThousandAndFifteenHundredBuyOptions() async {
+        // Given
+        let taxLots = createMockTaxLots()
+        let currentPrice = 25.0
+        let atrValue = 2.5
+        let (totalShares, totalCost, avgCostPerShare, currentProfitPercent) = calculatePositionValues(taxLots: taxLots, currentPrice: currentPrice)
+
+        // When
+        let result = service.calculateRecommendedBuyOrders(
+            symbol: "PENN",
+            atrValue: atrValue,
+            taxLotData: taxLots,
+            sharesAvailableForTrading: 150,
+            currentPrice: currentPrice,
+            totalShares: totalShares,
+            totalCost: totalCost,
+            avgCostPerShare: avgCostPerShare,
+            currentProfitPercent: currentProfitPercent
+        )
+
+        // Then
+        let thousandOrder = result.first { $0.description.contains("($1000)") }
+        let fifteenHundredOrder = result.first { $0.description.contains("($1500)") }
+        XCTAssertNotNil(thousandOrder, "Should include explicit $1000 buy option")
+        XCTAssertNotNil(fifteenHundredOrder, "Should include explicit $1500 buy option")
+
+        if let thousandOrder {
+            XCTAssertEqual(thousandOrder.shares, ceil(1000.0 / currentPrice), accuracy: 0.001)
+        }
+        if let fifteenHundredOrder {
+            XCTAssertEqual(fifteenHundredOrder.shares, ceil(1500.0 / currentPrice), accuracy: 0.001)
+        }
+    }
     
     func testCalculateRecommendedBuyOrders_OrdersSortedByIncreasingShares() async {
         // Given: A security trading under $350 to trigger additional order

--- a/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
+++ b/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
@@ -1069,8 +1069,8 @@ final class OrderRecommendationServiceTests: XCTestCase {
             // Exactly 1 share
             XCTAssertEqual(order.shares, 1.0, "Should recommend exactly 1 share")
             
-            // Cost under $2000 per constraints
-            XCTAssertLessThan(order.orderCost, 2000.0, "Order cost should be under $2000")
+            // Cost under $1750 per constraints
+            XCTAssertLessThan(order.orderCost, 1750.0, "Order cost should be under $1750")
         }
     }
 

--- a/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
+++ b/ccSchwabManagerTests/OrderRecommendationServiceTests.swift
@@ -1069,8 +1069,8 @@ final class OrderRecommendationServiceTests: XCTestCase {
             // Exactly 1 share
             XCTAssertEqual(order.shares, 1.0, "Should recommend exactly 1 share")
             
-            // Cost under $1750 per constraints
-            XCTAssertLessThan(order.orderCost, 1750.0, "Order cost should be under $1750")
+            // Cost under $2500 per constraints
+            XCTAssertLessThan(order.orderCost, 2500.0, "Order cost should be under $2500")
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the buy matcher priority updates (P/10 first, then trigger-based fallbacks)
- retain and preserve the explicit `$500` and `$1000` fixed-dollar buy recommendation options
- add a new explicit `$1500` fixed-dollar buy recommendation option
- keep the explicit `$2500` fixed-dollar option and overall buy-cap threshold
- refactor fixed-dollar option generation to a shared helper so `$1000/$1500/$2500` options use identical logic
- add unit test coverage verifying the `$1000` and `$1500` recommendations are emitted with expected share sizing

## Testing
- attempted Apple-native and repo test commands, but this cloud environment lacks Apple toolchain binaries (`xcodebuild`, `swift`), so execution is blocked
- validated logic changes through targeted test updates and diff inspection

## Notes
- explicit fixed-dollar options now include `$500`, `$1000`, `$1500`, and `$2500`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b91daf0-a3ae-4357-9867-2ec2f3143119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b91daf0-a3ae-4357-9867-2ec2f3143119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

